### PR TITLE
Fix CircleCI test script names

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ jobs:
           command: cd api && npm install
       - run:
           name: Run backend tests
-          command: yarn test:backend
+          command: yarn test:api
 
   # Test frontend
   test-frontend:
@@ -66,7 +66,7 @@ jobs:
           command: cd client && yarn install --frozen-lockfile
       - run:
           name: Run frontend tests
-          command: yarn test:frontend
+          command: yarn test:client
 
   # Lint code
   lint:


### PR DESCRIPTION
- Changed test:backend to test:api (matches package.json)
- Changed test:frontend to test:client (matches package.json)
- This should resolve the 'Command not found' errors