### PR TITLE
Fix API test configuration

### DIFF
--- a/api/jest.config.js
+++ b/api/jest.config.js
@@ -1,0 +1,40 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  roots: ['<rootDir>'],
+  testMatch: [
+    '**/__tests__/**/*.ts',
+    '**/?(*.)+(spec|test).ts'
+  ],
+  testPathIgnorePatterns: [
+    '/node_modules/',
+    '/__tests__/disabled/'
+  ],
+  transform: {
+    '^.+\\.ts$': 'ts-jest',
+  },
+  transformIgnorePatterns: [
+    'node_modules/(?!(yahoo-finance2|node-fetch)/)'
+  ],
+  collectCoverageFrom: [
+    '**/*.ts',
+    '!**/*.d.ts',
+    '!**/__tests__/**',
+    '!**/*.test.ts',
+    '!**/*.spec.ts'
+  ],
+  coverageDirectory: 'coverage',
+  coverageReporters: ['text', 'lcov', 'html'],
+  setupFilesAfterEnv: [],
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/$1'
+  },
+  testTimeout: 10000,
+  verbose: true,
+  extensionsToTreatAsEsm: ['.ts'],
+  globals: {
+    'ts-jest': {
+      useESM: true
+    }
+  }
+};

--- a/api/package.json
+++ b/api/package.json
@@ -3,7 +3,9 @@
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "jest",
+    "test:watch": "jest --watch",
+    "test:coverage": "jest --coverage",
     "start": "ts-node server.ts",
     "dev": "ts-node server.ts"
   },
@@ -25,7 +27,10 @@
   },
   "description": "",
   "devDependencies": {
+    "@types/jest": "^29.5.12",
     "@types/node": "^24.6.2",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.2",
     "ts-node": "^10.9.2",
     "typescript": "^5.9.3"
   }


### PR DESCRIPTION
- Added Jest and related dependencies to api/package.json
- Created jest.config.js for API tests
- Updated test script to use Jest instead of placeholder
- This should resolve the 'no test specified' error