### PR TITLE
Migrate to react-hook-form

### DIFF
--- a/client/TESTING_GUIDE.md
+++ b/client/TESTING_GUIDE.md
@@ -98,6 +98,15 @@ npm test -- --coverage
 - CSS support enabled
 - Coverage reporting with v8 provider
 
+### Utilities
+
+- `renderWithFormProvider` (`src/utils/test-utils.tsx`): Wraps components in react-hook-form `FormProvider` for form unit tests.
+  - Example:
+    ```tsx
+    import { renderWithFormProvider } from '../src/utils/test-utils';
+    renderWithFormProvider(<MyForm />, { defaultValues: { username: 'alice' } });
+    ```
+
 ## Mocking Strategy
 
 ### API Mocks

--- a/client/package.json
+++ b/client/package.json
@@ -25,6 +25,7 @@
     "axios": "^1.12.2",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
+    "react-hook-form": "^7.64.0",
     "react-router-dom": "^7.9.3"
   },
   "devDependencies": {

--- a/client/src/components/Backtesting/BacktestingSimple.tsx
+++ b/client/src/components/Backtesting/BacktestingSimple.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { useForm, FormProvider, Controller } from "react-hook-form";
 import {
   Box,
   Typography,
@@ -55,7 +56,8 @@ const BacktestingSimple: React.FC = () => {
   const [activeTab, setActiveTab] = useState(0);
   
   // State management
-  const [formData, setFormData] = useState<BacktestFormData>({
+  const methods = useForm<BacktestFormData>({
+    defaultValues: {
     strategy: "meanReversion",
     symbols: [],
     startDate: "2023-01-01",
@@ -83,7 +85,10 @@ const BacktestingSimple: React.FC = () => {
     breakoutThreshold: 0.01,
     minVolumeRatio: 1.5,
     confirmationPeriod: 2
+    }
   });
+  const { watch, setValue, getValues, control } = methods;
+  const formData = watch();
 
   const [results, setResults] = useState<BacktestResponse | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -99,10 +104,7 @@ const BacktestingSimple: React.FC = () => {
   const { runBacktest: runBacktestMutation, isLoading: backtestLoading } = useBacktest();
 
   const handleInputChange = (field: keyof BacktestFormData, value: string | number): void => {
-    setFormData(prev => ({
-      ...prev,
-      [field]: value
-    }));
+    setValue(field, value as any);
   };
 
   const handleTabChange = (event: React.SyntheticEvent, newValue: number) => {
@@ -110,7 +112,8 @@ const BacktestingSimple: React.FC = () => {
   };
 
   const handleRunBacktest = async (): Promise<void> => {
-    if (formData.symbols.length === 0) {
+    const current = getValues();
+    if ((current.symbols || []).length === 0) {
       setError("Please select at least one symbol");
       return;
     }
@@ -118,30 +121,30 @@ const BacktestingSimple: React.FC = () => {
     try {
       setError(null);
       const response = await runBacktestMutation({
-        strategy: formData.strategy,
-        symbols: formData.symbols,
-        startDate: formData.startDate,
-        endDate: formData.endDate,
-        initialCapital: formData.initialCapital,
-        sharesPerTrade: formData.sharesPerTrade,
+        strategy: current.strategy,
+        symbols: current.symbols,
+        startDate: current.startDate,
+        endDate: current.endDate,
+        initialCapital: current.initialCapital,
+        sharesPerTrade: current.sharesPerTrade,
         parameters: {
           ...strategyParameters,
           // Include strategy-specific parameters
-          window: formData.window,
-          threshold: formData.threshold,
-          fastWindow: formData.fastWindow,
-          slowWindow: formData.slowWindow,
-          maType: formData.maType,
-          rsiWindow: formData.rsiWindow,
-          rsiOverbought: formData.rsiOverbought,
-          rsiOversold: formData.rsiOversold,
-          momentumWindow: formData.momentumWindow,
-          momentumThreshold: formData.momentumThreshold,
-          multiplier: formData.multiplier,
-          lookbackWindow: formData.lookbackWindow,
-          breakoutThreshold: formData.breakoutThreshold,
-          minVolumeRatio: formData.minVolumeRatio,
-          confirmationPeriod: formData.confirmationPeriod,
+          window: current.window,
+          threshold: current.threshold,
+          fastWindow: current.fastWindow,
+          slowWindow: current.slowWindow,
+          maType: current.maType,
+          rsiWindow: current.rsiWindow,
+          rsiOverbought: current.rsiOverbought,
+          rsiOversold: current.rsiOversold,
+          momentumWindow: current.momentumWindow,
+          momentumThreshold: current.momentumThreshold,
+          multiplier: current.multiplier,
+          lookbackWindow: current.lookbackWindow,
+          breakoutThreshold: current.breakoutThreshold,
+          minVolumeRatio: current.minVolumeRatio,
+          confirmationPeriod: current.confirmationPeriod,
         }
       });
 
@@ -182,6 +185,7 @@ const BacktestingSimple: React.FC = () => {
   }
   
   return (
+    <FormProvider {...methods}>
     <Box>
       {/* Header */}
       <Box mb={3}>
@@ -552,24 +556,34 @@ const BacktestingSimple: React.FC = () => {
                       Date Range
                     </Typography>
                     <Stack spacing={2} direction={{ xs: 'column', sm: 'row' }}>
-                      <TextField
-                        label="Start Date"
-                        type="date"
-                        value={formData.startDate}
-                        onChange={(e) => handleInputChange('startDate', e.target.value)}
-                        InputLabelProps={{ shrink: true }}
-                        size="small"
-                        fullWidth
-                      />
-                      <TextField
-                        label="End Date"
-                        type="date"
-                        value={formData.endDate}
-                        onChange={(e) => handleInputChange('endDate', e.target.value)}
-                        InputLabelProps={{ shrink: true }}
-                        size="small"
-                        fullWidth
-                      />
+                        <Controller
+                          name="startDate"
+                          control={control}
+                          render={({ field }) => (
+                            <TextField
+                              {...field}
+                              label="Start Date"
+                              type="date"
+                              InputLabelProps={{ shrink: true }}
+                              size="small"
+                              fullWidth
+                            />
+                          )}
+                        />
+                        <Controller
+                          name="endDate"
+                          control={control}
+                          render={({ field }) => (
+                            <TextField
+                              {...field}
+                              label="End Date"
+                              type="date"
+                              InputLabelProps={{ shrink: true }}
+                              size="small"
+                              fullWidth
+                            />
+                          )}
+                        />
                     </Stack>
                   </Box>
 
@@ -579,24 +593,36 @@ const BacktestingSimple: React.FC = () => {
                       Trading Parameters
                     </Typography>
                     <Stack spacing={2} direction={{ xs: 'column', sm: 'row' }}>
-                      <TextField
-                        label="Initial Capital"
-                        type="number"
-                        value={formData.initialCapital}
-                        onChange={(e) => handleInputChange('initialCapital', parseFloat(e.target.value))}
-                        size="small"
-                        fullWidth
-                        helperText="Starting capital for backtest"
-                      />
-                      <TextField
-                        label="Shares Per Trade"
-                        type="number"
-                        value={formData.sharesPerTrade}
-                        onChange={(e) => handleInputChange('sharesPerTrade', parseInt(e.target.value))}
-                        size="small"
-                        fullWidth
-                        helperText="Number of shares to trade per signal"
-                      />
+                        <Controller
+                          name="initialCapital"
+                          control={control}
+                          render={({ field }) => (
+                            <TextField
+                              label="Initial Capital"
+                              type="number"
+                              size="small"
+                              fullWidth
+                              helperText="Starting capital for backtest"
+                              value={field.value}
+                              onChange={(e) => field.onChange(parseFloat(e.target.value))}
+                            />
+                          )}
+                        />
+                        <Controller
+                          name="sharesPerTrade"
+                          control={control}
+                          render={({ field }) => (
+                            <TextField
+                              label="Shares Per Trade"
+                              type="number"
+                              size="small"
+                              fullWidth
+                              helperText="Number of shares to trade per signal"
+                              value={field.value}
+                              onChange={(e) => field.onChange(parseInt(e.target.value))}
+                            />
+                          )}
+                        />
                     </Stack>
                   </Box>
 
@@ -808,6 +834,7 @@ const BacktestingSimple: React.FC = () => {
         </TabPanel>
       </Paper>
     </Box>
+    </FormProvider>
   );
 };
 

--- a/client/src/components/Backtesting/strategyComponents/BollingerBandsParams.tsx
+++ b/client/src/components/Backtesting/strategyComponents/BollingerBandsParams.tsx
@@ -1,52 +1,67 @@
 import React from 'react';
-import { TextField, Box, Typography, FormControl, InputLabel, Select, MenuItem, SelectChangeEvent } from '@mui/material';
+import { TextField, Box, Typography, FormControl, InputLabel, Select, MenuItem } from '@mui/material';
+import { useFormContext, Controller } from 'react-hook-form';
 import { BacktestFormData } from '../Backtesting.types';
 
-interface BollingerBandsParamsProps {
-  formData: BacktestFormData;
-  onInputChange: (field: keyof BacktestFormData, value: string | number) => void;
-}
-
-const BollingerBandsParams: React.FC<BollingerBandsParamsProps> = ({ formData, onInputChange }) => {
+const BollingerBandsParams: React.FC = () => {
+  const { control } = useFormContext<BacktestFormData>();
   return (
     <Box>
       <Typography variant="subtitle2" gutterBottom>
         Bollinger Bands Parameters
       </Typography>
       
-      <TextField
-        fullWidth
-        label="Moving Average Window (days)"
-        type="number"
-        value={formData.window}
-        onChange={(e) => onInputChange('window', parseInt(e.target.value) || 20)}
-        inputProps={{ min: 5, max: 50 }}
-        helperText="Number of days for the middle band (moving average)"
-        sx={{ mb: 2 }}
+      <Controller
+        name="window"
+        control={control}
+        render={({ field }) => (
+          <TextField
+            {...field}
+            fullWidth
+            label="Moving Average Window (days)"
+            type="number"
+            inputProps={{ min: 5, max: 50 }}
+            helperText="Number of days for the middle band (moving average)"
+            sx={{ mb: 2 }}
+            onChange={(e) => field.onChange(parseInt(e.target.value) || 20)}
+          />
+        )}
       />
 
-      <TextField
-        fullWidth
-        label="Standard Deviation Multiplier"
-        type="number"
-        value={formData.multiplier}
-        onChange={(e) => onInputChange('multiplier', parseFloat(e.target.value) || 2.0)}
-        inputProps={{ min: 1.0, max: 3.0, step: 0.1 }}
-        helperText="Multiplier for standard deviation to create upper/lower bands"
-        sx={{ mb: 2 }}
+      <Controller
+        name="multiplier"
+        control={control}
+        render={({ field }) => (
+          <TextField
+            {...field}
+            fullWidth
+            label="Standard Deviation Multiplier"
+            type="number"
+            inputProps={{ min: 1.0, max: 3.0, step: 0.1 }}
+            helperText="Multiplier for standard deviation to create upper/lower bands"
+            sx={{ mb: 2 }}
+            onChange={(e) => field.onChange(parseFloat(e.target.value) || 2.0)}
+          />
+        )}
       />
 
-      <FormControl fullWidth>
-        <InputLabel>Moving Average Type</InputLabel>
-        <Select
-          value={formData.maType}
-          label="Moving Average Type"
-          onChange={(e: SelectChangeEvent) => onInputChange('maType', e.target.value)}
-        >
-          <MenuItem value="SMA">Simple Moving Average (SMA)</MenuItem>
-          <MenuItem value="EMA">Exponential Moving Average (EMA)</MenuItem>
-        </Select>
-      </FormControl>
+      <Controller
+        name="maType"
+        control={control}
+        render={({ field }) => (
+          <FormControl fullWidth>
+            <InputLabel>Moving Average Type</InputLabel>
+            <Select
+              {...field}
+              label="Moving Average Type"
+              onChange={(e) => field.onChange(e.target.value)}
+            >
+              <MenuItem value="SMA">Simple Moving Average (SMA)</MenuItem>
+              <MenuItem value="EMA">Exponential Moving Average (EMA)</MenuItem>
+            </Select>
+          </FormControl>
+        )}
+      />
     </Box>
   );
 };

--- a/client/src/components/Backtesting/strategyComponents/BreakoutParams.tsx
+++ b/client/src/components/Backtesting/strategyComponents/BreakoutParams.tsx
@@ -1,13 +1,10 @@
 import React from 'react';
 import { TextField, Box, Typography, Grid } from '@mui/material';
+import { useFormContext, Controller } from 'react-hook-form';
 import { BacktestFormData } from '../Backtesting.types';
 
-interface BreakoutParamsProps {
-  formData: BacktestFormData;
-  onInputChange: (field: keyof BacktestFormData, value: string | number) => void;
-}
-
-const BreakoutParams: React.FC<BreakoutParamsProps> = ({ formData, onInputChange }) => {
+const BreakoutParams: React.FC = () => {
+  const { control } = useFormContext<BacktestFormData>();
   return (
     <Box>
       <Typography variant="subtitle2" gutterBottom>
@@ -22,26 +19,38 @@ const BreakoutParams: React.FC<BreakoutParamsProps> = ({ formData, onInputChange
         </Grid>
         
         <Grid item xs={6}>
-          <TextField
-            fullWidth
-            label="Lookback Window (days)"
-            type="number"
-            value={formData.lookbackWindow}
-            onChange={(e) => onInputChange('lookbackWindow', parseInt(e.target.value) || 20)}
-            inputProps={{ min: 10, max: 100 }}
-            helperText="Period to identify support/resistance levels"
+          <Controller
+            name="lookbackWindow"
+            control={control}
+            render={({ field }) => (
+              <TextField
+                {...field}
+                fullWidth
+                label="Lookback Window (days)"
+                type="number"
+                inputProps={{ min: 10, max: 100 }}
+                helperText="Period to identify support/resistance levels"
+                onChange={(e) => field.onChange(parseInt(e.target.value) || 20)}
+              />
+            )}
           />
         </Grid>
         
         <Grid item xs={6}>
-          <TextField
-            fullWidth
-            label="Breakout Threshold (%)"
-            type="number"
-            value={formData.breakoutThreshold * 100}
-            onChange={(e) => onInputChange('breakoutThreshold', parseFloat(e.target.value) / 100 || 0.01)}
-            inputProps={{ min: 0.5, max: 5, step: 0.1 }}
-            helperText="Minimum price move to confirm breakout"
+          <Controller
+            name="breakoutThreshold"
+            control={control}
+            render={({ field }) => (
+              <TextField
+                fullWidth
+                label="Breakout Threshold (%)"
+                type="number"
+                value={(field.value ?? 0) * 100}
+                onChange={(e) => field.onChange(parseFloat(e.target.value) / 100 || 0.01)}
+                inputProps={{ min: 0.5, max: 5, step: 0.1 }}
+                helperText="Minimum price move to confirm breakout"
+              />
+            )}
           />
         </Grid>
         
@@ -52,26 +61,38 @@ const BreakoutParams: React.FC<BreakoutParamsProps> = ({ formData, onInputChange
         </Grid>
         
         <Grid item xs={6}>
-          <TextField
-            fullWidth
-            label="Minimum Volume Ratio"
-            type="number"
-            value={formData.minVolumeRatio}
-            onChange={(e) => onInputChange('minVolumeRatio', parseFloat(e.target.value) || 1.5)}
-            inputProps={{ min: 1.0, max: 3.0, step: 0.1 }}
-            helperText="Volume must be X times above average"
+          <Controller
+            name="minVolumeRatio"
+            control={control}
+            render={({ field }) => (
+              <TextField
+                {...field}
+                fullWidth
+                label="Minimum Volume Ratio"
+                type="number"
+                inputProps={{ min: 1.0, max: 3.0, step: 0.1 }}
+                helperText="Volume must be X times above average"
+                onChange={(e) => field.onChange(parseFloat(e.target.value) || 1.5)}
+              />
+            )}
           />
         </Grid>
         
         <Grid item xs={6}>
-          <TextField
-            fullWidth
-            label="Confirmation Period (days)"
-            type="number"
-            value={formData.confirmationPeriod}
-            onChange={(e) => onInputChange('confirmationPeriod', parseInt(e.target.value) || 2)}
-            inputProps={{ min: 1, max: 10 }}
-            helperText="Days to hold position after breakout"
+          <Controller
+            name="confirmationPeriod"
+            control={control}
+            render={({ field }) => (
+              <TextField
+                {...field}
+                fullWidth
+                label="Confirmation Period (days)"
+                type="number"
+                inputProps={{ min: 1, max: 10 }}
+                helperText="Days to hold position after breakout"
+                onChange={(e) => field.onChange(parseInt(e.target.value) || 2)}
+              />
+            )}
           />
         </Grid>
       </Grid>

--- a/client/src/components/Backtesting/strategyComponents/MeanReversionParams.tsx
+++ b/client/src/components/Backtesting/strategyComponents/MeanReversionParams.tsx
@@ -1,38 +1,47 @@
 import React from 'react';
 import { TextField, Box, Typography } from '@mui/material';
+import { useFormContext, Controller } from 'react-hook-form';
 import { BacktestFormData } from '../Backtesting.types';
 
-interface MeanReversionParamsProps {
-  formData: BacktestFormData;
-  onInputChange: (field: keyof BacktestFormData, value: string | number) => void;
-}
-
-const MeanReversionParams: React.FC<MeanReversionParamsProps> = ({ formData, onInputChange }) => {
+const MeanReversionParams: React.FC = () => {
+  const { control } = useFormContext<BacktestFormData>();
   return (
     <Box>
       <Typography variant="subtitle2" gutterBottom>
         Mean Reversion Parameters
       </Typography>
       
-      <TextField
-        fullWidth
-        label="Moving Average Window (days)"
-        type="number"
-        value={formData.window}
-        onChange={(e) => onInputChange('window', parseInt(e.target.value) || 20)}
-        inputProps={{ min: 5, max: 200 }}
-        helperText="Number of days to calculate the moving average"
-        sx={{ mb: 2 }}
+      <Controller
+        name="window"
+        control={control}
+        render={({ field }) => (
+          <TextField
+            {...field}
+            fullWidth
+            label="Moving Average Window (days)"
+            type="number"
+            inputProps={{ min: 5, max: 200 }}
+            helperText="Number of days to calculate the moving average"
+            sx={{ mb: 2 }}
+            onChange={(e) => field.onChange(parseInt(e.target.value) || 20)}
+          />
+        )}
       />
 
-      <TextField
-        fullWidth
-        label="Threshold (%)"
-        type="number"
-        value={formData.threshold * 100}
-        onChange={(e) => onInputChange('threshold', parseFloat(e.target.value) / 100 || 0.05)}
-        inputProps={{ min: 1, max: 20, step: 0.1 }}
-        helperText="Percentage deviation from moving average to trigger buy/sell signals"
+      <Controller
+        name="threshold"
+        control={control}
+        render={({ field }) => (
+          <TextField
+            fullWidth
+            label="Threshold (%)"
+            type="number"
+            value={(field.value ?? 0) * 100}
+            onChange={(e) => field.onChange(parseFloat(e.target.value) / 100 || 0.05)}
+            inputProps={{ min: 1, max: 20, step: 0.1 }}
+            helperText="Percentage deviation from moving average to trigger buy/sell signals"
+          />
+        )}
       />
     </Box>
   );

--- a/client/src/components/Backtesting/strategyComponents/MomentumParams.tsx
+++ b/client/src/components/Backtesting/strategyComponents/MomentumParams.tsx
@@ -1,13 +1,10 @@
 import React from 'react';
 import { TextField, Box, Typography, Grid } from '@mui/material';
+import { useFormContext, Controller } from 'react-hook-form';
 import { BacktestFormData } from '../Backtesting.types';
 
-interface MomentumParamsProps {
-  formData: BacktestFormData;
-  onInputChange: (field: keyof BacktestFormData, value: string | number) => void;
-}
-
-const MomentumParams: React.FC<MomentumParamsProps> = ({ formData, onInputChange }) => {
+const MomentumParams: React.FC = () => {
+  const { control } = useFormContext<BacktestFormData>();
   return (
     <Box>
       <Typography variant="subtitle2" gutterBottom>
@@ -22,38 +19,56 @@ const MomentumParams: React.FC<MomentumParamsProps> = ({ formData, onInputChange
         </Grid>
         
         <Grid item xs={6}>
-          <TextField
-            fullWidth
-            label="RSI Window (days)"
-            type="number"
-            value={formData.rsiWindow}
-            onChange={(e) => onInputChange('rsiWindow', parseInt(e.target.value) || 14)}
-            inputProps={{ min: 5, max: 50 }}
-            helperText="RSI calculation period"
+          <Controller
+            name="rsiWindow"
+            control={control}
+            render={({ field }) => (
+              <TextField
+                {...field}
+                fullWidth
+                label="RSI Window (days)"
+                type="number"
+                inputProps={{ min: 5, max: 50 }}
+                helperText="RSI calculation period"
+                onChange={(e) => field.onChange(parseInt(e.target.value) || 14)}
+              />
+            )}
           />
         </Grid>
         
         <Grid item xs={6}>
-          <TextField
-            fullWidth
-            label="RSI Oversold Threshold"
-            type="number"
-            value={formData.rsiOversold}
-            onChange={(e) => onInputChange('rsiOversold', parseInt(e.target.value) || 30)}
-            inputProps={{ min: 10, max: 40 }}
-            helperText="RSI level considered oversold"
+          <Controller
+            name="rsiOversold"
+            control={control}
+            render={({ field }) => (
+              <TextField
+                {...field}
+                fullWidth
+                label="RSI Oversold Threshold"
+                type="number"
+                inputProps={{ min: 10, max: 40 }}
+                helperText="RSI level considered oversold"
+                onChange={(e) => field.onChange(parseInt(e.target.value) || 30)}
+              />
+            )}
           />
         </Grid>
         
         <Grid item xs={6}>
-          <TextField
-            fullWidth
-            label="RSI Overbought Threshold"
-            type="number"
-            value={formData.rsiOverbought}
-            onChange={(e) => onInputChange('rsiOverbought', parseInt(e.target.value) || 70)}
-            inputProps={{ min: 60, max: 90 }}
-            helperText="RSI level considered overbought"
+          <Controller
+            name="rsiOverbought"
+            control={control}
+            render={({ field }) => (
+              <TextField
+                {...field}
+                fullWidth
+                label="RSI Overbought Threshold"
+                type="number"
+                inputProps={{ min: 60, max: 90 }}
+                helperText="RSI level considered overbought"
+                onChange={(e) => field.onChange(parseInt(e.target.value) || 70)}
+              />
+            )}
           />
         </Grid>
         
@@ -64,26 +79,38 @@ const MomentumParams: React.FC<MomentumParamsProps> = ({ formData, onInputChange
         </Grid>
         
         <Grid item xs={6}>
-          <TextField
-            fullWidth
-            label="Momentum Window (days)"
-            type="number"
-            value={formData.momentumWindow}
-            onChange={(e) => onInputChange('momentumWindow', parseInt(e.target.value) || 10)}
-            inputProps={{ min: 5, max: 30 }}
-            helperText="Period for momentum calculation"
+          <Controller
+            name="momentumWindow"
+            control={control}
+            render={({ field }) => (
+              <TextField
+                {...field}
+                fullWidth
+                label="Momentum Window (days)"
+                type="number"
+                inputProps={{ min: 5, max: 30 }}
+                helperText="Period for momentum calculation"
+                onChange={(e) => field.onChange(parseInt(e.target.value) || 10)}
+              />
+            )}
           />
         </Grid>
         
         <Grid item xs={6}>
-          <TextField
-            fullWidth
-            label="Momentum Threshold (%)"
-            type="number"
-            value={formData.momentumThreshold * 100}
-            onChange={(e) => onInputChange('momentumThreshold', parseFloat(e.target.value) / 100 || 0.02)}
-            inputProps={{ min: 1, max: 10, step: 0.1 }}
-            helperText="Minimum momentum percentage for signals"
+          <Controller
+            name="momentumThreshold"
+            control={control}
+            render={({ field }) => (
+              <TextField
+                fullWidth
+                label="Momentum Threshold (%)"
+                type="number"
+                value={(field.value ?? 0) * 100}
+                onChange={(e) => field.onChange(parseFloat(e.target.value) / 100 || 0.02)}
+                inputProps={{ min: 1, max: 10, step: 0.1 }}
+                helperText="Minimum momentum percentage for signals"
+              />
+            )}
           />
         </Grid>
       </Grid>

--- a/client/src/components/Backtesting/strategyComponents/MovingAverageCrossoverParams.tsx
+++ b/client/src/components/Backtesting/strategyComponents/MovingAverageCrossoverParams.tsx
@@ -1,52 +1,67 @@
 import React from 'react';
-import { TextField, Box, Typography, FormControl, InputLabel, Select, MenuItem, SelectChangeEvent } from '@mui/material';
+import { TextField, Box, Typography, FormControl, InputLabel, Select, MenuItem } from '@mui/material';
+import { useFormContext, Controller } from 'react-hook-form';
 import { BacktestFormData } from '../Backtesting.types';
 
-interface MovingAverageCrossoverParamsProps {
-  formData: BacktestFormData;
-  onInputChange: (field: keyof BacktestFormData, value: string | number) => void;
-}
-
-const MovingAverageCrossoverParams: React.FC<MovingAverageCrossoverParamsProps> = ({ formData, onInputChange }) => {
+const MovingAverageCrossoverParams: React.FC = () => {
+  const { control } = useFormContext<BacktestFormData>();
   return (
     <Box>
       <Typography variant="subtitle2" gutterBottom>
         Moving Average Crossover Parameters
       </Typography>
-      
-      <TextField
-        fullWidth
-        label="Fast Moving Average Window (days)"
-        type="number"
-        value={formData.fastWindow}
-        onChange={(e) => onInputChange('fastWindow', parseInt(e.target.value) || 10)}
-        inputProps={{ min: 5, max: 50 }}
-        helperText="Number of days for the fast moving average"
-        sx={{ mb: 2 }}
+
+      <Controller
+        name="fastWindow"
+        control={control}
+        render={({ field }) => (
+          <TextField
+            {...field}
+            fullWidth
+            label="Fast Moving Average Window (days)"
+            type="number"
+            inputProps={{ min: 5, max: 50 }}
+            helperText="Number of days for the fast moving average"
+            sx={{ mb: 2 }}
+            onChange={(e) => field.onChange(parseInt(e.target.value) || 10)}
+          />
+        )}
       />
 
-      <TextField
-        fullWidth
-        label="Slow Moving Average Window (days)"
-        type="number"
-        value={formData.slowWindow}
-        onChange={(e) => onInputChange('slowWindow', parseInt(e.target.value) || 30)}
-        inputProps={{ min: 10, max: 200 }}
-        helperText="Number of days for the slow moving average"
-        sx={{ mb: 2 }}
+      <Controller
+        name="slowWindow"
+        control={control}
+        render={({ field }) => (
+          <TextField
+            {...field}
+            fullWidth
+            label="Slow Moving Average Window (days)"
+            type="number"
+            inputProps={{ min: 10, max: 200 }}
+            helperText="Number of days for the slow moving average"
+            sx={{ mb: 2 }}
+            onChange={(e) => field.onChange(parseInt(e.target.value) || 30)}
+          />
+        )}
       />
 
-      <FormControl fullWidth>
-        <InputLabel>Moving Average Type</InputLabel>
-        <Select
-          value={formData.maType}
-          label="Moving Average Type"
-          onChange={(e: SelectChangeEvent) => onInputChange('maType', e.target.value)}
-        >
-          <MenuItem value="SMA">Simple Moving Average (SMA)</MenuItem>
-          <MenuItem value="EMA">Exponential Moving Average (EMA)</MenuItem>
-        </Select>
-      </FormControl>
+      <Controller
+        name="maType"
+        control={control}
+        render={({ field }) => (
+          <FormControl fullWidth>
+            <InputLabel>Moving Average Type</InputLabel>
+            <Select
+              {...field}
+              label="Moving Average Type"
+              onChange={(e) => field.onChange(e.target.value)}
+            >
+              <MenuItem value="SMA">Simple Moving Average (SMA)</MenuItem>
+              <MenuItem value="EMA">Exponential Moving Average (EMA)</MenuItem>
+            </Select>
+          </FormControl>
+        )}
+      />
     </Box>
   );
 };

--- a/client/src/components/Backtesting/strategyComponents/StrategyParamsSelector.tsx
+++ b/client/src/components/Backtesting/strategyComponents/StrategyParamsSelector.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Box, Divider } from '@mui/material';
+import { useFormContext } from 'react-hook-form';
 import { BacktestFormData } from '../Backtesting.types';
 import {
   MeanReversionParams,
@@ -9,39 +10,24 @@ import {
   BreakoutParams
 } from './index';
 
-interface StrategyParamsSelectorProps {
-  strategy: string;
-  formData: BacktestFormData;
-  onInputChange: (field: keyof BacktestFormData, value: string | number) => void;
-}
+const StrategyParamsSelector: React.FC = () => {
+  const { watch } = useFormContext<BacktestFormData>();
+  const strategy = watch('strategy');
 
-const StrategyParamsSelector: React.FC<StrategyParamsSelectorProps> = ({ 
-  strategy, 
-  formData, 
-  onInputChange 
-}) => {
   const renderStrategyParams = () => {
-    console.log("Rendering Strategy Params"); 
-    console.log(strategy);
-    
     switch (strategy) {
       case 'meanReversion':
-        return <MeanReversionParams formData={formData} onInputChange={onInputChange} />;
-      
+        return <MeanReversionParams />;
       case 'movingAverageCrossover':
-        return <MovingAverageCrossoverParams formData={formData} onInputChange={onInputChange} />;
-      
+        return <MovingAverageCrossoverParams />;
       case 'momentum':
-        return <MomentumParams formData={formData} onInputChange={onInputChange} />;
-      
+        return <MomentumParams />;
       case 'bollingerBands':
-        return <BollingerBandsParams formData={formData} onInputChange={onInputChange} />;
-      
+        return <BollingerBandsParams />;
       case 'breakout':
-        return <BreakoutParams formData={formData} onInputChange={onInputChange} />;
-      
+        return <BreakoutParams />;
       default:
-        return <MeanReversionParams formData={formData} onInputChange={onInputChange} />;
+        return <MeanReversionParams />;
     }
   };
 

--- a/client/src/components/Signup/Signup.types.ts
+++ b/client/src/components/Signup/Signup.types.ts
@@ -1,7 +1,7 @@
 // Signup component types and interfaces
 
 export interface SignupFormData {
-  name: string;
+  username: string;
   email: string;
   password: string;
   confirmPassword: string;

--- a/client/src/utils/test-utils.tsx
+++ b/client/src/utils/test-utils.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { render, RenderOptions } from '@testing-library/react';
+import { FormProvider, useForm } from 'react-hook-form';
+
+type ProvidersProps = {
+  children: React.ReactNode;
+  defaultValues?: Record<string, any>;
+};
+
+function RHFProvider({ children, defaultValues }: ProvidersProps) {
+  const methods = useForm({ defaultValues });
+  return <FormProvider {...methods}>{children}</FormProvider>;
+}
+
+export function renderWithFormProvider(
+  ui: React.ReactElement,
+  { defaultValues, ...options }: RenderOptions & { defaultValues?: Record<string, any> } = {}
+) {
+  return render(<RHFProvider defaultValues={defaultValues}>{ui}</RHFProvider>, options);
+}

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -2723,6 +2723,11 @@ react-dom@^19.1.1:
   dependencies:
     scheduler "^0.27.0"
 
+react-hook-form@^7.64.0:
+  version "7.64.0"
+  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-7.64.0.tgz#7820961b773d0b4706baa506e8aa53a0e904b6f7"
+  integrity sha512-fnN+vvTiMLnRqKNTVhDysdrUay0kUUAymQnFIznmgDvapjveUWOOPqMNzPg+A+0yf9DuE2h6xzBjN1s+Qx8wcg==
+
 react-is@^16.13.1, react-is@^16.7.0:
   version "16.13.1"
   resolved "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz"


### PR DESCRIPTION
Migrate client-side form handling to `react-hook-form` to streamline state management, validation, and testing.

---
<a href="https://cursor.com/background-agent?bcId=bc-9f5c8d9a-ae34-4c05-9d29-6ea7c9ac6743"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9f5c8d9a-ae34-4c05-9d29-6ea7c9ac6743"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

