### PR TITLE
Implement sentiment analysis trading strategy

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -96,6 +96,25 @@ function createStrategyConfigs(strategyType: string, symbols: string[]): Strateg
       });
       break;
 
+    case 'sentiment':
+    case 'sentimentanalysis':
+      strategies.push({
+        name: 'SentimentAnalysis',
+        enabled: true,
+        parameters: {
+          lookbackDays: parseInt(process.env.SENTIMENT_LOOKBACK_DAYS || '3'),
+          pollIntervalMinutes: parseInt(process.env.SENTIMENT_POLL_MINUTES || '15'),
+          minArticles: parseInt(process.env.SENTIMENT_MIN_ARTICLES || '3'),
+          buyThreshold: parseFloat(process.env.SENTIMENT_BUY_THRESHOLD || '0.4'),
+          sellThreshold: parseFloat(process.env.SENTIMENT_SELL_THRESHOLD || '-0.4'),
+          titleWeight: parseFloat(process.env.SENTIMENT_TITLE_WEIGHT || '2.0'),
+          recencyHalfLifeHours: parseInt(process.env.SENTIMENT_HALF_LIFE_HOURS || '12'),
+          tiingoApiKey: process.env.TIINGO_API_KEY
+        },
+        symbols
+      });
+      break;
+
     default:
       console.warn(`Unknown strategy type: ${strategyType}. Using default MovingAverage strategy.`);
       strategies.push({

--- a/src/bot/TradingBot.ts
+++ b/src/bot/TradingBot.ts
@@ -4,6 +4,7 @@ import { Portfolio, PortfolioStatus } from '../portfolio';
 import { TradingConfig, ConfigManager } from '../config/tradingConfig';
 import { TradingDatabase, Trade, TradingSession, PortfolioSnapshot } from '../database/tradingSchema';
 import { BaseStrategy, Signal } from '../strategies/baseStrategy';
+import { SentimentAnalysisStrategy } from '../strategies/sentimentAnalysisStrategy';
 import { MovingAverageStrategy } from '../strategies/movingAverage';
 import { MeanReversionStrategy } from '../strategies/meanReversionStrategy';
 import { MomentumStrategy } from '../strategies/momentumStrategy';
@@ -93,6 +94,21 @@ export class TradingBot extends EventEmitter {
           case 'BollingerBands':
             const { window: bbWindow, multiplier } = strategyConfig.parameters;
             strategy = new BollingerBandsStrategy({ window: bbWindow, multiplier, maType: 'SMA' });
+            break;
+
+          case 'SentimentAnalysis':
+            const { lookbackDays, pollIntervalMinutes, minArticles, buyThreshold, sellThreshold, titleWeight, recencyHalfLifeHours, tiingoApiKey } = strategyConfig.parameters;
+            strategy = new SentimentAnalysisStrategy({
+              symbol,
+              lookbackDays,
+              pollIntervalMinutes,
+              minArticles,
+              buyThreshold,
+              sellThreshold,
+              titleWeight,
+              recencyHalfLifeHours,
+              tiingoApiKey,
+            });
             break;
 
           default:
@@ -310,7 +326,7 @@ export class TradingBot extends EventEmitter {
         quantity,
         price,
         timestamp: new Date().toISOString(),
-        strategy: 'MovingAverage',
+        strategy: this.strategies.get(symbol)?.getStrategyName() || 'Unknown',
         mode: tradingConfig.mode,
         pnl: signal === 'SELL' ? this.calculateTradePnL(symbol, price) : undefined
       };

--- a/src/config/tradingConfig.ts
+++ b/src/config/tradingConfig.ts
@@ -49,6 +49,20 @@ export const defaultTradingConfig: TradingConfig = {
       enabled: true,
       parameters: { shortWindow: 5, longWindow: 10 },
       symbols: ['SPY', 'QQQ', 'AAPL', 'TSLA']
+    },
+    {
+      name: 'SentimentAnalysis',
+      enabled: false,
+      parameters: {
+        lookbackDays: 3,
+        pollIntervalMinutes: 15,
+        minArticles: 3,
+        buyThreshold: 0.4,
+        sellThreshold: -0.4,
+        titleWeight: 2.0,
+        recencyHalfLifeHours: 12
+      },
+      symbols: ['AAPL']
     }
   ],
   dataProvider: {

--- a/src/dataProviders/TiingoNewsProvider.ts
+++ b/src/dataProviders/TiingoNewsProvider.ts
@@ -1,0 +1,77 @@
+import fetch from 'node-fetch';
+import { DataProvider, NewsArticle } from './baseProvider';
+
+interface TiingoNewsItem {
+  id?: number | string;
+  tickers?: string[];
+  title: string;
+  description?: string;
+  url?: string;
+  articleUrl?: string;
+  source?: string;
+  publishedDate?: string; // ISO
+  publishedAt?: string;   // Some APIs use this
+}
+
+export interface TiingoNewsOptions {
+  startDate?: string; // ISO
+  endDate?: string;   // ISO
+  limit?: number;
+}
+
+/**
+ * Tiingo News Provider
+ * Fetches news articles for a given ticker using Tiingo's News API
+ * Docs: https://www.tiingo.com/documentation/news
+ */
+export class TiingoNewsProvider extends DataProvider {
+  private apiKey: string;
+  private baseUrl = 'https://api.tiingo.com/tiingo/news';
+
+  constructor(apiKey?: string) {
+    super();
+    const key = apiKey || process.env.TIINGO_API_KEY;
+    if (!key) {
+      throw new Error('TIINGO_API_KEY is required to use TiingoNewsProvider');
+    }
+    this.apiKey = key;
+  }
+
+  async getNews(symbol: string, options: TiingoNewsOptions = {}): Promise<NewsArticle[]> {
+    const params = new URLSearchParams();
+    params.set('tickers', symbol.toUpperCase());
+    if (options.startDate) params.set('startDate', options.startDate);
+    if (options.endDate) params.set('endDate', options.endDate);
+    if (options.limit) params.set('limit', String(options.limit));
+    params.set('token', this.apiKey);
+
+    const url = `${this.baseUrl}?${params.toString()}`;
+
+    try {
+      const res = await fetch(url);
+      if (!res.ok) {
+        const text = await res.text();
+        throw new Error(`Tiingo news request failed: ${res.status} ${res.statusText} - ${text}`);
+      }
+      const data = (await res.json()) as TiingoNewsItem[];
+      return (data || []).map((item) => this.mapToNewsArticle(item, symbol));
+    } catch (error) {
+      console.error('Error fetching Tiingo news:', error);
+      return [];
+    }
+  }
+
+  private mapToNewsArticle(item: TiingoNewsItem, fallbackTicker: string): NewsArticle {
+    const publishedAt = item.publishedDate || item.publishedAt || new Date().toISOString();
+    const url = item.url || item.articleUrl;
+    return {
+      id: item.id ? String(item.id) : undefined,
+      ticker: (item.tickers && item.tickers[0]) || fallbackTicker.toUpperCase(),
+      title: item.title,
+      description: item.description,
+      url,
+      source: item.source,
+      publishedAt,
+    };
+  }
+}

--- a/src/dataProviders/baseProvider.ts
+++ b/src/dataProviders/baseProvider.ts
@@ -1,13 +1,28 @@
+export interface NewsArticle {
+  id?: string;
+  ticker: string;
+  title: string;
+  description?: string;
+  url?: string;
+  source?: string;
+  publishedAt: string; // ISO string
+}
+
 export class DataProvider {
-  async getQuote(symbol:string): Promise<any> {
+  async getQuote(symbol: string): Promise<any> {
     return null;
   }
 
-  async getHistorical(symbol:string, interval = 'day', from:string, to:string): Promise<any[]> {
+  async getHistorical(symbol: string, interval = 'day', from: string, to: string): Promise<any[]> {
     return [];
   }
 
-  connectStream(symbols: string[], onData:(data:any)=>void): Promise<any> {
+  // Optional: Providers that support news can override this
+  async getNews(_symbol: string, _options?: { startDate?: string; endDate?: string; limit?: number }): Promise<NewsArticle[]> {
+    return [];
+  }
+
+  connectStream(symbols: string[], onData: (data: any) => void): Promise<any> {
     return Promise.resolve();
   }
 }

--- a/src/strategies/baseStrategy.ts
+++ b/src/strategies/baseStrategy.ts
@@ -7,6 +7,8 @@
 
 export type Signal = 'BUY' | 'SELL' | null;
 
+import { NewsArticle } from '../dataProviders/baseProvider';
+
 export interface BaseStrategy {
   /**
    * Add a new price point to the strategy
@@ -30,6 +32,11 @@ export interface BaseStrategy {
    * Reset the strategy state
    */
   reset(): void;
+
+  /**
+   * Optional: Ingest recent news articles for sentiment-driven strategies
+   */
+  addNews?(articles: NewsArticle[]): void;
 }
 
 export abstract class AbstractStrategy implements BaseStrategy {
@@ -53,5 +60,10 @@ export abstract class AbstractStrategy implements BaseStrategy {
   protected getAverage(prices: number[]): number {
     if (prices.length === 0) return 0;
     return prices.reduce((sum, price) => sum + price, 0) / prices.length;
+  }
+
+  // Default no-op for strategies that don't use news
+  addNews(articles: NewsArticle[]): void {
+    // no-op by default
   }
 }

--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -52,3 +52,9 @@ export {
 
 // Strategy runner
 export { runStrategy, StrategyConfig, Trade, BacktestResult } from './runStrategy';
+
+// Sentiment Analysis Strategy
+export {
+  SentimentAnalysisStrategy,
+  SentimentAnalysisConfig
+} from './sentimentAnalysisStrategy';

--- a/src/strategies/sentimentAnalysisStrategy.ts
+++ b/src/strategies/sentimentAnalysisStrategy.ts
@@ -1,0 +1,177 @@
+import { AbstractStrategy, Signal } from './baseStrategy';
+import { NewsArticle } from '../dataProviders/baseProvider';
+import { TiingoNewsProvider, TiingoNewsOptions } from '../dataProviders/TiingoNewsProvider';
+
+export interface SentimentAnalysisConfig {
+  symbol: string;
+  lookbackDays: number;            // How many days of news to consider
+  pollIntervalMinutes: number;     // How often to poll Tiingo for new news
+  minArticles: number;             // Minimum articles required to generate a signal
+  buyThreshold: number;            // Aggregate sentiment threshold to trigger BUY (e.g., 0.4)
+  sellThreshold: number;           // Aggregate sentiment threshold to trigger SELL (e.g., -0.4)
+  titleWeight?: number;            // Weight of title vs description (default: 2.0)
+  recencyHalfLifeHours?: number;   // Half-life for recency decay (default: 12)
+  tiingoApiKey?: string;           // Optional API key override; otherwise uses env TIINGO_API_KEY
+}
+
+/**
+ * SentimentAnalysisStrategy
+ * Heuristic sentiment scoring of Tiingo news to produce BUY/SELL signals.
+ */
+export class SentimentAnalysisStrategy extends AbstractStrategy {
+  private readonly config: SentimentAnalysisConfig;
+  private readonly newsProvider: TiingoNewsProvider;
+  private lastSignal: Signal = null;
+  private lastPollAt: number = 0;
+  private aggregatedArticles: NewsArticle[] = [];
+
+  constructor(config: Omit<SentimentAnalysisConfig, 'symbol'> & { symbol: string }) {
+    super();
+    this.config = {
+      titleWeight: 2.0,
+      recencyHalfLifeHours: 12,
+      ...config,
+    };
+    this.newsProvider = new TiingoNewsProvider(this.config.tiingoApiKey);
+  }
+
+  addPrice(_price: number): void {
+    // Price is not used directly; we poll for news on a timer and update signal.
+    const now = Date.now();
+    const pollMs = this.config.pollIntervalMinutes * 60 * 1000;
+    if (now - this.lastPollAt < pollMs) {
+      this.lastSignal = null;
+      return;
+    }
+    this.lastPollAt = now;
+
+    // Fire-and-forget; bot calls getSignal subsequently
+    void this.pollAndScoreNews();
+    this.lastSignal = null;
+  }
+
+  getSignal(): Signal {
+    return this.lastSignal;
+  }
+
+  getStrategyName(): string {
+    return 'SentimentAnalysis';
+  }
+
+  reset(): void {
+    this.aggregatedArticles = [];
+    this.lastSignal = null;
+    this.lastPollAt = 0;
+  }
+
+  addNews(articles: NewsArticle[]): void {
+    // Merge new articles and re-score immediately
+    this.aggregatedArticles = this.dedupeById([...articles, ...this.aggregatedArticles]);
+    this.scoreAndUpdateSignal();
+  }
+
+  private async pollAndScoreNews(): Promise<void> {
+    try {
+      const endDate = new Date();
+      const startDate = new Date(endDate.getTime() - this.config.lookbackDays * 24 * 60 * 60 * 1000);
+
+      const options: TiingoNewsOptions = {
+        startDate: startDate.toISOString().split('T')[0],
+        endDate: endDate.toISOString().split('T')[0],
+        limit: 100,
+      };
+      const news = await this.newsProvider.getNews(this.config.symbol, options);
+      this.addNews(news);
+    } catch (error) {
+      // Swallow and keep running
+      // eslint-disable-next-line no-console
+      console.error('SentimentAnalysisStrategy poll error:', error);
+    }
+  }
+
+  private scoreAndUpdateSignal(): void {
+    const now = Date.now();
+    const halfLifeMs = (this.config.recencyHalfLifeHours || 12) * 60 * 60 * 1000;
+    const lambda = Math.log(2) / halfLifeMs; // decay rate
+
+    let weightedSum = 0;
+    let weightTotal = 0;
+    let considered = 0;
+
+    for (const article of this.aggregatedArticles) {
+      if (!article.publishedAt) continue;
+      const ts = new Date(article.publishedAt).getTime();
+      const ageMs = Math.max(0, now - ts);
+      const weight = Math.exp(-lambda * ageMs);
+
+      const score = this.scoreArticle(article);
+      weightedSum += score * weight;
+      weightTotal += weight;
+      considered++;
+    }
+
+    const aggregate = weightTotal > 0 ? weightedSum / weightTotal : 0;
+
+    if (considered < this.config.minArticles) {
+      this.lastSignal = null;
+      return;
+    }
+
+    if (aggregate >= this.config.buyThreshold) {
+      this.lastSignal = 'BUY';
+    } else if (aggregate <= this.config.sellThreshold) {
+      this.lastSignal = 'SELL';
+    } else {
+      this.lastSignal = null;
+    }
+  }
+
+  private scoreArticle(article: NewsArticle): number {
+    const title = (article.title || '').toLowerCase();
+    const desc = (article.description || '').toLowerCase();
+
+    const positives = [
+      'beat', 'beats', 'exceed', 'exceeds', 'surge', 'record', 'upgrade', 'outperform',
+      'buyback', 'dividend increase', 'profit', 'profitable', 'growth', 'raises guidance',
+      'raise guidance', 'optimism', 'bullish', 'strong', 'above expectations', 'tops', 'soars'
+    ];
+    const negatives = [
+      'miss', 'misses', 'fall', 'falls', 'drop', 'drops', 'downgrade', 'underperform',
+      'loss', 'losses', 'decline', 'weak', 'cuts guidance', 'cut guidance', 'bearish',
+      'investigation', 'probe', 'lawsuit', 'sec', 'fraud', 'layoff', 'layoffs', 'warns', 'warning'
+    ];
+
+    const titleWeight = this.config.titleWeight || 2.0;
+    const titleScore = this.keywordScore(title, positives, negatives) * titleWeight;
+    const descScore = this.keywordScore(desc, positives, negatives);
+    const raw = titleScore + descScore;
+
+    // Normalize roughly to [-1, 1]
+    const maxPossible = 6; // heuristic cap
+    const normalized = Math.max(-1, Math.min(1, raw / maxPossible));
+    return normalized;
+  }
+
+  private keywordScore(text: string, positives: string[], negatives: string[]): number {
+    let score = 0;
+    for (const p of positives) {
+      if (text.includes(p)) score += 1;
+    }
+    for (const n of negatives) {
+      if (text.includes(n)) score -= 1;
+    }
+    return score;
+  }
+
+  private dedupeById(articles: NewsArticle[]): NewsArticle[] {
+    const seen = new Set<string>();
+    const out: NewsArticle[] = [];
+    for (const a of articles) {
+      const key = a.id ? `${a.id}` : `${a.ticker}-${a.title}-${a.publishedAt}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      out.push(a);
+    }
+    return out;
+  }
+}


### PR DESCRIPTION
Add a Tiingo news data provider and a `SentimentAnalysis` trading strategy to enable news-driven trading decisions.

The `SentimentAnalysisStrategy` uses a keyword-based heuristic with recency decay to score news articles and generate buy/sell signals, without requiring an external LLM. It polls Tiingo for news on a configurable interval.

---
<a href="https://cursor.com/background-agent?bcId=bc-3361e89b-4b54-404d-8535-49155851af2e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3361e89b-4b54-404d-8535-49155851af2e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

