### PR TITLE
Fix CircleCI workflows following official documentation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -323,58 +323,91 @@ workflows:
   # PR workflow - Run tests and validation on pull requests
   build:
     jobs:
-      - install-dependencies
+      - install-dependencies:
+          filters:
+            branches:
+              ignore: main
       - test-backend:
           requires:
             - install-dependencies
+          filters:
+            branches:
+              ignore: main
       - test-frontend:
           requires:
             - install-dependencies
+          filters:
+            branches:
+              ignore: main
       - lint:
           requires:
             - install-dependencies
+          filters:
+            branches:
+              ignore: main
       - build-images:
           requires:
             - test-backend
             - test-frontend
             - lint
-    filters:
-      branches:
-        ignore: main
+          filters:
+            branches:
+              ignore: main
 
   # Main branch workflow - Deploy to QA after PR merge
   staging:
     jobs:
-      - install-dependencies
+      - install-dependencies:
+          filters:
+            branches:
+              only: main
       - test-backend:
           requires:
             - install-dependencies
+          filters:
+            branches:
+              only: main
       - test-frontend:
           requires:
             - install-dependencies
+          filters:
+            branches:
+              only: main
       - lint:
           requires:
             - install-dependencies
+          filters:
+            branches:
+              only: main
       - build-images:
           requires:
             - test-backend
             - test-frontend
             - lint
+          filters:
+            branches:
+              only: main
       - migrate-qa-database:
           requires:
             - build-images
           context: tradebot-qa
+          filters:
+            branches:
+              only: main
       - deploy-railway-qa:
           requires:
             - migrate-qa-database
           context: tradebot-qa
+          filters:
+            branches:
+              only: main
       - deploy-client-railway-qa:
           requires:
             - build-images
           context: tradebot-qa
-    filters:
-      branches:
-        only: main
+          filters:
+            branches:
+              only: main
 
   # Production release pipeline - Deploy to production on GitHub releases
   release:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -320,8 +320,30 @@ jobs:
 
 # Define workflows
 workflows:
-  # Main workflow - Run tests on all branches, deploy only on main
-  build-and-test:
+  # PR workflow - Run tests and validation on pull requests
+  build:
+    jobs:
+      - install-dependencies
+      - test-backend:
+          requires:
+            - install-dependencies
+      - test-frontend:
+          requires:
+            - install-dependencies
+      - lint:
+          requires:
+            - install-dependencies
+      - build-images:
+          requires:
+            - test-backend
+            - test-frontend
+            - lint
+    filters:
+      branches:
+        ignore: main
+
+  # Main branch workflow - Deploy to QA after PR merge
+  staging:
     jobs:
       - install-dependencies
       - test-backend:
@@ -342,23 +364,17 @@ workflows:
           requires:
             - build-images
           context: tradebot-qa
-          filters:
-            branches:
-              only: main
       - deploy-railway-qa:
           requires:
             - migrate-qa-database
           context: tradebot-qa
-          filters:
-            branches:
-              only: main
       - deploy-client-railway-qa:
           requires:
             - build-images
           context: tradebot-qa
-          filters:
-            branches:
-              only: main
+    filters:
+      branches:
+        only: main
 
   # Production release pipeline - Deploy to production on GitHub releases
   release:


### PR DESCRIPTION
- Split into separate 'build' and 'staging' workflows
- build workflow: runs on all branches except main (PRs)
- staging workflow: runs only on main branch (includes migrations)
- Follows CircleCI docs pattern for workflow separation
- Ensures migration jobs run on main branch merges